### PR TITLE
Always poll_complete and never miss a notification

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,6 @@ impl<T> Sending<T> {
 
 	fn push(&mut self, item: T) {
 		self.items.push_back(item);
-		self.flushing = false;
 	}
 
 	// process all the sends into the sink.


### PR DESCRIPTION
Simple break is not enough. We need to ensure that we don't return `Ready(())` if there are messages to send.