### PR TITLE
Allow us to figure out, who participated in a round

### DIFF
--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -202,6 +202,21 @@ impl<Candidate, Digest, AuthorityId, Signature> Accumulator<Candidate, Digest, A
 		self.proposal.as_ref().map(|p| &p.proposal)
 	}
 
+	/// Returns a HashSet of AuthorityIds we've seen participating at any step in this round
+	pub fn participants(&self) -> HashSet<&AuthorityId> {
+		let mut participants = self.prepares.keys()
+			.chain(self.commits.keys())
+			.chain(self.advance_round.iter())
+			.collect::<HashSet<&AuthorityId>>();
+
+		if self.proposal.is_some() {
+			// we only accepted the proposals, if they were made by the proposer
+			participants.insert(&self.round_proposer);
+		}
+
+		participants
+	}
+
 	/// Inspect the current consensus state.
 	pub fn state(&self) -> &State<Candidate, Digest, Signature> {
 		&self.state

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ pub trait Context {
 	) {
 		// The awkward let _ is used to suppress the unused variables
 		// warning (https://github.com/rust-lang/rust/issues/26487)
-		let _ = (proposal, round, next_round, reason);
+		let _ = (accumulator, round, next_round, reason);
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,7 @@ pub trait Context {
 	/// `Some` if there was one on the current `round`.
 	fn on_advance_round(
 		&self, 
-		accumulator: Option<&Accumulator<Self::Candidate, Self::Digest, Self::AuthorityId, Self::Signature>>,
+		accumulator: &Accumulator<Self::Candidate, Self::Digest, Self::AuthorityId, Self::Signature>,
 		round: usize, 
 		next_round: usize,
 		reason: AdvanceRoundReason,
@@ -753,7 +753,7 @@ impl<C: Context> Strategy<C> {
 
 		// notify the context that we are about to advance round.
 		context.on_advance_round(
-			Some(&self.current_accumulator),
+			&self.current_accumulator,
 			self.current_round(),
 			round,
 			reason,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,7 @@ pub trait Context {
 	/// `Some` if there was one on the current `round`.
 	fn on_advance_round(
 		&self, 
-		proposal: Option<&Self::Candidate>,
+		accumulator: Option<&Accumulator<Self::Candidate, Self::Digest, Self::AuthorityId, Self::Signature>>,
 		round: usize, 
 		next_round: usize,
 		reason: AdvanceRoundReason,
@@ -753,7 +753,7 @@ impl<C: Context> Strategy<C> {
 
 		// notify the context that we are about to advance round.
 		context.on_advance_round(
-			self.current_accumulator.proposal(),
+			Some(&self.current_accumulator),
 			self.current_round(),
 			round,
 			reason,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -206,7 +206,7 @@ impl Context for TestContext {
 
 	fn on_advance_round(
 		&self, 
-		_proposal: Option<&Accumulator<Self::Candidate, Self::Digest, Self::AuthorityId, Self::Signature>>,
+		_acc: &Accumulator<Self::Candidate, Self::Digest, Self::AuthorityId, Self::Signature>,
 		_round: usize, 
 		_next_round: usize,
 		_reason: AdvanceRoundReason,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -206,7 +206,7 @@ impl Context for TestContext {
 
 	fn on_advance_round(
 		&self, 
-		_proposal: Option<&Candidate>, 
+		_proposal: Option<&Accumulator<Self::Candidate, Self::Digest, Self::AuthorityId, Self::Signature>>,
 		_round: usize, 
 		_next_round: usize,
 		_reason: AdvanceRoundReason,


### PR DESCRIPTION
- Adds helper on Accumulator to return all seen participants
- Rather than returning proposal `on_advance_round` now contains the 
Accumulator (from which one can gather the proposal)