### PR TITLE
Add Parity-Codec Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,14 @@ repository = "https://github.com/paritytech/rhododendron"
 futures = "0.1.17"
 error-chain = "0.12"
 log = "0.3"
+parity-codec = { version = "2.0", optional = true}
+parity-codec-derive = { version = "2.0", optional = true}
 
 [dev-dependencies]
 tokio-core = "0.1.12"
 tokio-timer = "0.1.2"
+parity-codec = "2.0"
+parity-codec-derive = "2.0"
+
+[features]
+codec = ['parity-codec', 'parity-codec-derive']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/paritytech/rhododendron"
 futures = "0.1.17"
 error-chain = "0.12"
 log = "0.3"
-parity-codec = { version = "2.0", optional = true}
-parity-codec-derive = { version = "2.0", optional = true}
+parity-codec = { version = "2.0", optional = true }
+parity-codec-derive = { version = "2.0", optional = true }
 
 [dev-dependencies]
 tokio-core = "0.1.12"

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -136,6 +136,7 @@ struct Proposal<Candidate, Digest, Signature> {
 
 /// Misbehavior which can occur.
 #[derive(Debug, Clone)]
+#[cfg_attr(any(test, feature="codec"), derive(Encode, Decode))]
 pub enum Misbehavior<Digest, Signature> {
 	/// Proposed out-of-turn.
 	ProposeOutOfTurn(usize, Digest, Signature),

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -24,6 +24,7 @@ use ::{Vote, LocalizedMessage, LocalizedProposal};
 
 /// Justification for some state at a given round.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, feature="codec"), derive(Encode, Decode))]
 pub struct UncheckedJustification<D, S> {
 	/// The round.
 	pub round_number: usize,
@@ -81,6 +82,7 @@ impl<D, S> UncheckedJustification<D, S> {
 
 /// A checked justification.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, feature="codec"), derive(Encode, Decode))]
 pub struct Justification<D,S>(UncheckedJustification<D,S>);
 
 impl<D, S> Justification<D, S> {
@@ -103,6 +105,7 @@ pub type PrepareJustification<D, S> = Justification<D, S>;
 
 /// The round's state, based on imported messages.
 #[derive(PartialEq, Eq, Debug)]
+#[cfg_attr(any(test, feature="codec"), derive(Encode, Decode))]
 pub enum State<Candidate, Digest, Signature> {
 	/// No proposal yet.
 	Begin,
@@ -117,12 +120,14 @@ pub enum State<Candidate, Digest, Signature> {
 }
 
 #[derive(Debug, Default)]
+#[cfg_attr(any(test, feature="codec"), derive(Encode, Decode))]
 struct VoteCounts {
 	prepared: usize,
 	committed: usize,
 }
 
 #[derive(Debug)]
+#[cfg_attr(any(test, feature="codec"), derive(Encode, Decode))]
 struct Proposal<Candidate, Digest, Signature> {
 	proposal: Candidate,
 	digest: Digest,
@@ -448,16 +453,16 @@ mod tests {
 	use super::*;
 	use ::{LocalizedMessage, LocalizedProposal, LocalizedVote};
 
-	#[derive(Clone, PartialEq, Eq, Debug)]
+	#[derive(Clone, PartialEq, Eq, Debug, Encode, Decode)]
 	pub struct Candidate(usize);
 
-	#[derive(Hash, PartialEq, Eq, Clone, Debug)]
+	#[derive(Hash, PartialEq, Eq, Clone, Debug, Encode, Decode)]
 	pub struct Digest(usize);
 
-	#[derive(Hash, PartialEq, Eq, Debug, Clone)]
+	#[derive(Hash, PartialEq, Eq, Debug, Encode, Decode, Clone)]
 	pub struct AuthorityId(usize);
 
-	#[derive(PartialEq, Eq, Clone, Debug)]
+	#[derive(PartialEq, Eq, Clone, Debug, Encode, Decode)]
 	pub struct Signature(usize, usize);
 
 	#[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,12 @@ extern crate log;
 #[cfg(test)]
 extern crate tokio_timer;
 
+#[cfg(any(test, feature="codec"))]
+extern crate parity_codec as codec;
+#[cfg(any(test, feature="codec"))]
+#[macro_use]
+extern crate parity_codec_derive;
+
 use std::collections::{HashMap, BTreeMap, VecDeque};
 use std::collections::hash_map;
 use std::fmt::Debug;
@@ -62,6 +68,7 @@ mod tests;
 
 /// Votes during a round.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, feature="codec"), derive(Encode, Decode))]
 pub enum Vote<D> {
 	/// Prepare to vote for proposal with digest D.
 	Prepare(usize, D),
@@ -85,6 +92,7 @@ impl<D> Vote<D> {
 /// Messages over the proposal.
 /// Each message carries an associated round number.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, feature="codec"), derive(Encode, Decode))]
 pub enum Message<C, D> {
 	/// A proposal itself.
 	Propose(usize, C),
@@ -100,6 +108,7 @@ impl<C, D> From<Vote<D>> for Message<C, D> {
 
 /// A localized proposal message. Contains two signed pieces of data.
 #[derive(Debug, Clone)]
+#[cfg_attr(any(test, feature="codec"), derive(Encode, Decode))]
 pub struct LocalizedProposal<C, D, V, S> {
 	/// The round number.
 	pub round_number: usize,
@@ -117,6 +126,7 @@ pub struct LocalizedProposal<C, D, V, S> {
 
 /// A localized vote message, including the sender.
 #[derive(Debug, Clone)]
+#[cfg_attr(any(test, feature="codec"), derive(Encode, Decode))]
 pub struct LocalizedVote<D, V, S> {
 	/// The message sent.
 	pub vote: Vote<D>,
@@ -128,6 +138,7 @@ pub struct LocalizedVote<D, V, S> {
 
 /// A localized message.
 #[derive(Debug, Clone)]
+#[cfg_attr(any(test, feature="codec"), derive(Encode, Decode))]
 pub enum LocalizedMessage<C, D, V, S> {
 	/// A proposal.
 	Propose(LocalizedProposal<C, D, V, S>),
@@ -161,6 +172,7 @@ impl<C, D, V, S> From<LocalizedVote<D, V, S>> for LocalizedMessage<C, D, V, S> {
 
 /// A reason why we are advancing round.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(any(test, feature="codec"), derive(Encode, Decode))]
 pub enum AdvanceRoundReason {
 	/// We received enough `AdvanceRound` messages to advance to the next round.
 	Timeout,
@@ -233,6 +245,7 @@ pub trait Context {
 
 /// Communication that can occur between participants in consensus.
 #[derive(Debug, Clone)]
+#[cfg_attr(any(test, feature="codec"), derive(Encode, Decode))]
 pub enum Communication<C, D, V, S> {
 	/// A consensus message (proposal or vote)
 	Consensus(LocalizedMessage<C, D, V, S>),
@@ -328,6 +341,7 @@ fn bft_threshold(nodes: usize, max_faulty: usize) -> usize {
 
 /// Committed successfully.
 #[derive(Debug, Clone)]
+#[cfg_attr(any(test, feature="codec"), derive(Encode, Decode))]
 pub struct Committed<C, D, S> {
 	/// The candidate committed for. This will be unknown if
 	/// we never witnessed the proposal of the last round.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -91,16 +91,16 @@ impl<T: Clone> Future for Network<T> {
 	}
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Hash)]
 struct Candidate(usize);
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Hash)]
 struct Digest(usize);
 
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode, Hash)]
 struct AuthorityId(usize);
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Encode, Decode)]
 struct Signature(Message<Candidate, Digest>, AuthorityId);
 
 #[derive(Debug)]


### PR DESCRIPTION
Add support for en- & decoding our public `enum` and `structs` with 
parity-codec by enabling the newly introduced `codec` feature (disabled by 
default).