### PR TITLE
Make round proposer and other params public for future logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rhododendron"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Asynchronously safe BFT protocol, futures-based implementation"
 license = "GPL-3.0"

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -161,9 +161,15 @@ pub struct Accumulator<Candidate, Digest, AuthorityId, Signature>
 	AuthorityId: Hash + Eq + Clone,
 	Signature: Eq + Clone,
 {
+	// The round this accumulator is currently on
 	pub round_number: usize,
+
+	// Threshold of prepare messages required to make progress
 	pub threshold: usize,
+
+	// Current proposer/authority for this round
 	pub round_proposer: AuthorityId,
+
 	proposal: Option<Proposal<Candidate, Digest, Signature>>,
 	prepares: HashMap<AuthorityId, (Digest, Signature)>,
 	commits: HashMap<AuthorityId, (Digest, Signature)>,

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -161,13 +161,13 @@ pub struct Accumulator<Candidate, Digest, AuthorityId, Signature>
 	AuthorityId: Hash + Eq + Clone,
 	Signature: Eq + Clone,
 {
-	// The round this accumulator is currently on
+	/// The round this accumulator is currently on
 	pub round_number: usize,
 
-	// Threshold of prepare messages required to make progress
+	/// Threshold of prepare messages required to make progress
 	pub threshold: usize,
 
-	// Current proposer/authority for this round
+	/// Current proposer/authority for this round
 	pub round_proposer: AuthorityId,
 
 	proposal: Option<Proposal<Candidate, Digest, Signature>>,

--- a/src/accumulator.rs
+++ b/src/accumulator.rs
@@ -161,9 +161,9 @@ pub struct Accumulator<Candidate, Digest, AuthorityId, Signature>
 	AuthorityId: Hash + Eq + Clone,
 	Signature: Eq + Clone,
 {
-	round_number: usize,
-	threshold: usize,
-	round_proposer: AuthorityId,
+	pub round_number: usize,
+	pub threshold: usize,
+	pub round_proposer: AuthorityId,
 	proposal: Option<Proposal<Candidate, Digest, Signature>>,
 	prepares: HashMap<AuthorityId, (Digest, Signature)>,
 	commits: HashMap<AuthorityId, (Digest, Signature)>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ use self::accumulator::State;
 
 pub use self::accumulator::{Accumulator, Justification, PrepareJustification, UncheckedJustification, Misbehavior};
 
-mod accumulator;
+pub mod accumulator;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
This exposes 3 parameters in the rhododendron accumulator, most importantly the round proposer for logging in substrate as well as alternative client implementations.

Would love to get your input @rphmeier.